### PR TITLE
Fix _onData handler when multiple packets are needed

### DIFF
--- a/lib/UpsClient.js
+++ b/lib/UpsClient.js
@@ -323,8 +323,8 @@ class UpsClient extends events.EventEmitter {
 
   _onData (buffer) {
     const s = buffer.toString('utf8')
-    const lines = s.slice(0, -1).split('\n')
     this._response += s
+    const lines = this._response.split('\n')
     for (const line of lines) {
       if (line.startsWith(this._expectedResponse)) {
         /** Emitted when a valid response has been received from `upsd`.
@@ -334,6 +334,7 @@ class UpsClient extends events.EventEmitter {
         this.emit('response', new UpsResponse(
           this._request, this._response.slice(0, -1))
         )
+        break
       }
     }
   }


### PR DESCRIPTION
This started with an inexplicable `warning: timeout after 15s` warning showing up from my UPS, which I had no problem running `upsc` commands against from the machine I run homebridge on.

Digging in, I realized that when receiving data from a remote `upsd` instance, where 1500 byte packets are involved, sometimes the large listing of `VAR` results is split across multiple packets. This is generally handled OK, except in one very specific case- where the expected response text, such as `END LIST VARS cp850`, is split across two packets. In my case, I frequently saw `END LIST` at the end of one packet, and ` VARS cp850\n` as the start of the next. We would ultimately time out, as the current code couldn't handle this case.

Tweak the "find expected text" algorithm to consider the full response received thus far, rather than just the most recent packet. As part of this, don't assume we can throw away the last character either- it isn't always a '\n' if data is split across packets.

This fully fixes my issues, and allows the remote UPS to be working as expected.

Note that you likely won't see this when connected to a localhost UPS, as the MTU size over the loopback interface is usually 65536.