### PR TITLE
Add optional 'device' config attribute

### DIFF
--- a/cli/ups.js
+++ b/cli/ups.js
@@ -58,6 +58,9 @@ Parameters:
   ${b('-t')} ${u('timeout')}, ${b('--timeout=')}${u('timeout')}
   Set timeout to ${u('timeout')} seconds instead of default ${b(5)}.
 
+  ${b('-d')} ${u('device')}, ${b('--device=')}${u('device')}
+  Explicitly set UPS ${u('device')} name instead of first in sorted map.
+
 Commands:
   ${usage.info}
   ${description.info}
@@ -142,6 +145,11 @@ class Main extends homebridgeLib.CommandLineTool {
         clargs.options.timeout = homebridgeLib.OptionParser.toInt(
           'timeout', value, 1, 60, true
         )
+      })
+      .option('d', 'device', (value) => {
+        clargs.options.device = homebridgeLib.OptionParser.toString(
+	        'device', value, true
+	      )
       })
       .parameter('command', (value) => {
         if (usage[value] == null || typeof this[value] !== 'function') {

--- a/lib/UpsClient.js
+++ b/lib/UpsClient.js
@@ -226,6 +226,7 @@ class UpsClient extends events.EventEmitter {
     * @param {string} params.host - The `upsd` hostname and port (default: `localhost:3493`).
     * @param {string} params.username - The username (as specified in `upsd.users`).
     * @param {string} params.password - The password (as specified in `upsd.users`).
+    * @param {string} params.device - The ups device name from `upsc -l` command.
   */
   constructor (params) {
     super()
@@ -240,11 +241,13 @@ class UpsClient extends events.EventEmitter {
       .stringKey('name')
       .stringKey('username')
       .stringKey('password')
+      .stringKey('device')
       .intKey('timeout', 1, 60)
       .parse(params)
     this._host = this._params.hostname + ':' + this._params.port
     this._requestId = 0
     this._devices = {}
+    this._prefDevice = this._params.device
   }
 
   /** The name of the UPS Daemon.
@@ -424,7 +427,9 @@ class UpsClient extends events.EventEmitter {
     const map = {}
     const descriptionByName = await this._getMap('UPS')
     for (const name of Object.keys(descriptionByName).sort()) {
-      map[name] = new UpsDevice({ client: this, name })
+      if (!this._prefDevice || this._prefDevice === name) {
+        map[name] = new UpsDevice({ client: this, name })
+      }
     }
     return map
   }

--- a/lib/UpsPlatform.js
+++ b/lib/UpsPlatform.js
@@ -57,6 +57,7 @@ class UpsPlatform extends homebridgeLib.Platform {
           .hostKey()
           .stringKey('username')
           .stringKey('password')
+          .stringKey('device')
           .on('userInputError', (error) => {
             this.warn('config.json: hosts[%d]: %s', i, error)
           })
@@ -69,7 +70,8 @@ class UpsPlatform extends homebridgeLib.Platform {
             name: config.name,
             host: config.hostname + ':' + config.port,
             username: config.username,
-            password: config.password
+            password: config.password,
+            device: config.device
           })
         } catch (error) {
           this.error(error)


### PR DESCRIPTION
With certain configurations there can be multiple ups devices available, but not necessarily connected / active:

```
root@NAS ~ # upsc -l | sort
bcmxcp
megatec
tripplite
usbhid
root@NAS ~ # upsc bcmxcp
Error: Driver not connected
root@NAS ~ # upsc usbhid
battery.charge: 100
battery.charge.low: 10
battery.charge.warning: 50
...
```

Since the plugin creates a sorted map ([here](https://github.com/ebaauw/homebridge-ups/blob/main/lib/UpsClient.js#L426)) the plugin will successfully connect to the server, but fail to load the UPS attributes, and timeout.

```
[UPS] NAS UPS: warning: timeout after 15s
[UPS] NAS UPS: Network UPS Tools upsd FW_5.27.105-149-gbfc7d29a3 - http://www.networkupstools.org/, API v1.2
[UPS] NAS UPS: warning: timeout after 15s
[UPS] NAS UPS: Network UPS Tools upsd FW_5.27.105-149-gbfc7d29a3 - http://www.networkupstools.org/, API v1.2
[UPS] NAS UPS: warning: timeout after 15s
[UPS] NAS UPS: Network UPS Tools upsd FW_5.27.105-149-gbfc7d29a3 - http://www.networkupstools.org/, API v1.2
...
```

This PR adds a new optional config attribute `device` which facilitates the end-user explicitly informing the plugin which device should be used. If not provided, the existing behavior is maintained.

An example updated Homebridge plugin config:

```
            "hosts": [
                {
                    "host": "10.0.10.10",
                    "name": "NAS UPS",
                    "username": "username",
                    "password": "password",
                    "device": "usbhid"
                }
```


