### PR TITLE
Fix: "TypeError: Cannot redefine property: logLevel"

### DIFF
--- a/lib/UpsHost.js
+++ b/lib/UpsHost.js
@@ -78,7 +78,6 @@ class UpsHost extends homebridgeLib.Delegate {
             constants
           })  
         }
-        const logLevel = this.upsAccessories[id].logLevel;
       }
       this.debug('initialised')
       this.emit('initialised')

--- a/lib/UpsHost.js
+++ b/lib/UpsHost.js
@@ -14,7 +14,6 @@ class UpsHost extends homebridgeLib.Delegate {
     super(platform, host.name)
     this.name = host.name
     this.upsAccessories = {}
-    this.logLevels = {}
     this.client = new UpsClient(host)
     this.client
       .on('connect', (host) => { this.debug('connected to %s', host) })
@@ -77,9 +76,9 @@ class UpsHost extends homebridgeLib.Delegate {
               : constants['ups.firmware'],
             device,
             constants
-          })
-          this.logLevels[id] = this.upsAccessories[id].logLevel
+          })  
         }
+        const logLevel = this.upsAccessories[id].logLevel;
       }
       this.debug('initialised')
       this.emit('initialised')

--- a/lib/UpsHost.js
+++ b/lib/UpsHost.js
@@ -14,6 +14,7 @@ class UpsHost extends homebridgeLib.Delegate {
     super(platform, host.name)
     this.name = host.name
     this.upsAccessories = {}
+    this.logLevels = {}
     this.client = new UpsClient(host)
     this.client
       .on('connect', (host) => { this.debug('connected to %s', host) })
@@ -77,9 +78,7 @@ class UpsHost extends homebridgeLib.Delegate {
             device,
             constants
           })
-          Object.defineProperty(this, 'logLevel', {
-            get () { return this.upsAccessories[id].logLevel }
-          })
+          this.logLevels[id] = this.upsAccessories[id].logLevel
         }
       }
       this.debug('initialised')


### PR DESCRIPTION
Refactored UpsHost.js to store logLevel for each UpsAccessory instance in a separate object, resolving TypeError when multiple UPS devices are connected to a single host.

This closes issue #19 